### PR TITLE
Replace null property attribute with isrequired Bug #12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   matrix:
     - ENGINE=lucee@5
     - ENGINE=lucee@4.5
-    #- ENGINE=adobe@2018
+    - ENGINE=adobe@2018
     - ENGINE=adobe@2016
     - ENGINE=adobe@11
 

--- a/factory.cfc
+++ b/factory.cfc
@@ -41,6 +41,10 @@ component accessors="true" output="false" {
 		return constants;
 	}
 
+	private struct function getFactoryConfig() {
+		return variables.factoryConfig;
+	}
+
 	private struct function getFrameworkConfig() {
 		return {
 			applicationKey = 'framework.one',

--- a/factory.cfc
+++ b/factory.cfc
@@ -41,10 +41,6 @@ component accessors="true" output="false" {
 		return constants;
 	}
 
-	private struct function getFactoryConfig() {
-		return variables.factoryConfig;
-	}
-
 	private struct function getFrameworkConfig() {
 		return {
 			applicationKey = 'framework.one',

--- a/model/factory/data.cfc
+++ b/model/factory/data.cfc
@@ -1,4 +1,4 @@
-﻿component accessors=true {
+component accessors=true {
 
 	property BeanFactory;
 	property BeanService;
@@ -395,7 +395,7 @@
 				"minlength" = ( structKeyExists(prop,"minlength") ? prop.minlength : "" ),
 				"maxlength" = ( structKeyExists(prop,"maxlength") ? prop.maxlength : "" )
 			});
-			metadata["datatype"] = getDatatype(metadata.valtype,metadata.sqltype);
+			metadata["datatype"] = getDatatype( valtype=metadata.valtype, sqltype=metadata.sqltype );
 
 			validatePropertyMetadata( metadata=metadata, beanname=arguments.beanname );
 		}
@@ -457,6 +457,10 @@
 		}
 		if ( !isBoolean(arguments.metadata.isrequired) ) {
 			throw("The 'isrequired' attribute must be a boolean" & message);
+		}
+
+		if ( arguments.metadata.valtype == "foreignkey" && arguments.metadata.sqltype != "cf_sql_integer" ) {
+			throw("When the 'valtype' attribute is 'foreignkey', the 'cfsqltype' attribute must be an integer" & message);
 		}
 
 		if ( len(arguments.metadata.minvalue) && !isNumeric(arguments.metadata.minvalue) ) {

--- a/model/factory/data.cfc
+++ b/model/factory/data.cfc
@@ -380,7 +380,7 @@
 				"columnName" = ( structKeyExists(prop,"columnName") ? prop.columnName : "" ),
 				"insert" = ( structKeyExists(prop,"insert") ? prop.insert : true ),
 				"isidentity" = ( structKeyExists(prop,"isidentity") ? prop.isidentity : false ),
-				"null" = ( structKeyExists(prop,"null") ? prop.null : false ),
+				"isrequired" = ( structKeyExists(prop,"isrequired") ? prop.isrequired : false ),
 				"sqltype" = getCfSqlType(prop.cfsqltype),
 				"valtype" = ( structKeyExists(prop,"valtype") ? prop.valtype : "" ),
 				"regex" = ( structKeyExists(prop,"regex") ? prop.regex : "" ),
@@ -450,8 +450,8 @@
 		if ( !isBoolean(arguments.metadata.isidentity) ) {
 			throw("The 'isidentity' attribute must be a boolean" & message);
 		}
-		if ( !isBoolean(arguments.metadata.null) ) {
-			throw("The 'null' attribute must be a boolean" & message);
+		if ( !isBoolean(arguments.metadata.isrequired) ) {
+			throw("The 'isrequired' attribute must be a boolean" & message);
 		}
 
 		if ( len(arguments.metadata.minvalue) && !isNumeric(arguments.metadata.minvalue) ) {

--- a/model/factory/data.cfc
+++ b/model/factory/data.cfc
@@ -40,6 +40,10 @@
 		return variables.beanmaps[ arguments.bean ];
 	}
 
+	public struct function getBeanMaps() {
+		return variables.beanmaps;
+	}
+
 	public array function getBeanListProperties( required array beans, boolean eagerFetch=false ) {
 		var result = [];
 		arguments.beans.each(function(bean){

--- a/model/factory/data.cfc
+++ b/model/factory/data.cfc
@@ -338,6 +338,7 @@
 					datatype = "string";
 				break;
 
+				case "bigint":
 				case "integer":
 				case "float":
 					datatype = "numeric";

--- a/model/gateways/data.cfc
+++ b/model/gateways/data.cfc
@@ -82,7 +82,7 @@ component accessors=true {
 	private void function addParams( required component querycfc, required struct sqlparams ) {
 		for ( var fieldkey in arguments.sqlparams ) {
 			var field = arguments.sqlparams[ fieldkey ];
-			arguments.querycfc.addParam( name=fieldkey, value=field.value, null=field.null, cfsqltype=field.cfsqltype );
+			arguments.querycfc.addParam( name=fieldkey, value=field.value, null=field.usenull, cfsqltype=field.cfsqltype );
 		}
 	}
 

--- a/model/gateways/data.cfc
+++ b/model/gateways/data.cfc
@@ -1,9 +1,9 @@
 component accessors=true {
 
+	property dsn;
 	property storedprocTag;
 
-	public function init( dsn ) {
-		variables.dsn = arguments.dsn;
+	public function init() {
 		return this;
 	}
 

--- a/model/services/mssql.cfc
+++ b/model/services/mssql.cfc
@@ -54,17 +54,17 @@
 		required string propname,
 		required string columnname,
 		required string sqltype,
-		required boolean isNull
+		required boolean isRequired
 	) {
 		var fieldresult = "";
 
-		if ( arguments.sqltype == "cf_sql_integer" && arguments.isNull ) {
+		if ( arguments.sqltype == "cf_sql_integer" && !arguments.isRequired ) {
 			fieldresult &= "ISNULL(";
 		}
 
 		fieldresult &= arguments.columnname;
 
-		if ( arguments.sqltype == "cf_sql_integer" && arguments.isNull ) {
+		if ( arguments.sqltype == "cf_sql_integer" && !arguments.isRequired ) {
 			fieldresult &= ",0)";
 		}
 

--- a/model/services/mysql.cfc
+++ b/model/services/mysql.cfc
@@ -52,17 +52,17 @@
 		required string propname,
 		required string columnname,
 		required string sqltype,
-		required boolean isNull
+		required boolean isRequired
 	) {
 		var fieldresult = "";
 
-		if ( arguments.sqltype == "cf_sql_integer" && arguments.isNull ) {
+		if ( arguments.sqltype == "cf_sql_integer" && !arguments.isRequired ) {
 			fieldresult &= "IFNULL(";
 		}
 
 		fieldresult &= arguments.columnname;
 
-		if ( arguments.sqltype == "cf_sql_integer" && arguments.isNull ) {
+		if ( arguments.sqltype == "cf_sql_integer" && !arguments.isRequired ) {
 			fieldresult &= ",0)";
 		}
 

--- a/model/services/sql.cfc
+++ b/model/services/sql.cfc
@@ -261,7 +261,7 @@ component accessors="true" output="false" {
 						propname=arguments.propname,
 						columnname=columnname,
 						sqltype=arguments.prop.sqltype,
-						isNull=!arguments.prop.isrequired
+						isRequired=arguments.prop.isrequired
 					);
 				}
 				else {

--- a/model/services/sql.cfc
+++ b/model/services/sql.cfc
@@ -169,6 +169,7 @@ component accessors="true" output="false" {
 		var primarykey = getPrimaryKeyField( beanmap=arguments.beanmap );
 
 		var rBeanMap = {
+			database = arguments.beanmap.database,
 			schema = arguments.relationship.joinSchema,
 			table = arguments.relationship.joinTable
 		};

--- a/model/services/sql.cfc
+++ b/model/services/sql.cfc
@@ -430,7 +430,7 @@ component accessors="true" output="false" {
 		var sqlparam = {
 			value = arguments.value,
 			cfsqltype = arguments.prop.sqltype,
-			"null" = false
+			usenull = false
 		};
 
 		if (
@@ -442,7 +442,7 @@ component accessors="true" output="false" {
 			)
 		) {
 			sqlparam.value = "";
-			sqlparam.null = true;
+			sqlparam.usenull = true;
 		}
 
 		return sqlparam;

--- a/model/services/sql.cfc
+++ b/model/services/sql.cfc
@@ -1,4 +1,4 @@
-﻿component accessors="true" output="false" {
+component accessors="true" output="false" {
 
 	property DataGateway;
 	property DataFactory;
@@ -256,12 +256,12 @@
 				break;
 
 			default:
-				if ( len(arguments.prop.columnName) || ( arguments.prop.sqltype == "cf_sql_integer" && arguments.prop.null ) ) {
+				if ( len(arguments.prop.columnName) || ( arguments.prop.sqltype == "cf_sql_integer" && !arguments.prop.isrequired ) ) {
 					field &= getServerTypeService().getSelectAsField(
 						propname=arguments.propname,
 						columnname=columnname,
 						sqltype=arguments.prop.sqltype,
-						isNull=arguments.prop.null
+						isNull=!arguments.prop.isrequired
 					);
 				}
 				else {
@@ -435,7 +435,7 @@
 
 		if (
 			arguments.allowNull
-			&& arguments.prop.null
+			&& !arguments.prop.isrequired
 			&& (
 				!len(arguments.value)
 				|| isNullInteger( sqltype=arguments.prop.sqltype, value=arguments.value )

--- a/model/services/validation.cfc
+++ b/model/services/validation.cfc
@@ -76,9 +76,8 @@ component accessors="true" {
 		var validationMessage = "";
 
 		var displayname = arguments.beanProperty.displayname;
-		var isRequired = !(arguments.beanProperty.null);
 
-		if( isRequired ){
+		if( arguments.beanProperty.isrequired ){
 			validationMessage = validateRequired( value=arguments.value, displayname=displayname );
 			if( len(trim(validationMessage)) ){
 				arrayAppend(errors, validationMessage);

--- a/model/services/validation.cfc
+++ b/model/services/validation.cfc
@@ -18,8 +18,9 @@ component accessors="true" {
 			}
 
 			var value = arguments.bean.getPropertyValue( propertyname=name );
+			var messages = validateBeanProperty( value=value, beanProperty=beanProperty );
 
-			errors = validateBeanProperty( value=value, beanProperty=beanProperty );
+			errors.append(messages, true);
 		}
 
 		return errors;

--- a/model/services/validation.cfc
+++ b/model/services/validation.cfc
@@ -79,7 +79,11 @@ component accessors="true" {
 		var displayname = arguments.beanProperty.displayname;
 
 		if( arguments.beanProperty.isrequired ){
-			validationMessage = validateRequired( value=arguments.value, displayname=displayname );
+			validationMessage = validateRequired(
+				datatype=arguments.beanproperty.datatype,
+				value=arguments.value,
+				displayname=displayname
+			);
 			if( len(trim(validationMessage)) ){
 				arrayAppend(errors, validationMessage);
 			}
@@ -196,15 +200,15 @@ component accessors="true" {
 		return returnString;
 	}
 
-	private string function validateRequired( required string value, required string displayname ){
+	private string function validateRequired( required string datatype, required string value, required string displayname ){
 		var returnString = "";
 
-		// todo: add validation for a fkColumn related to a relationship join
-		/*if( arguments.datatype == 'numeric' && arguments.value <= 0){
+		// validate numeric fields like fk fields that are marked required and default to 0
+		if( arguments.datatype == 'numeric' && arguments.value <= 0){
 			returnString = arguments.displayname & " is required.";
-		} else*/
+		}
 
-		if( !len(trim(arguments.value)) ){
+		else if( !len(trim(arguments.value)) ){
 			returnString = arguments.displayname & " is required.";
 		}
 

--- a/model/services/validation.cfc
+++ b/model/services/validation.cfc
@@ -49,6 +49,7 @@ component accessors="true" {
 				}
 			break;
 
+			case "foreignkey":
 			case "numeric":
 				if( !isNumeric(arguments.value) ){
 					returnString = arguments.displayname & " must be a numeric value.";
@@ -203,8 +204,7 @@ component accessors="true" {
 	private string function validateRequired( required string datatype, required string value, required string displayname ){
 		var returnString = "";
 
-		// validate numeric fields like fk fields that are marked required and default to 0
-		if( arguments.datatype == 'numeric' && arguments.value <= 0){
+		if( arguments.datatype == "foreignkey" && arguments.value <= 0){
 			returnString = arguments.displayname & " is required.";
 		}
 

--- a/samples/model/beans/user.cfc
+++ b/samples/model/beans/user.cfc
@@ -13,10 +13,10 @@ component accessors="true" extends="cfmlDataMapper.model.base.bean"
 	property name="updateDate" cfsqltype="timestamp" isrequired="true" default="";
 
 	// many-to-one relationships
-	property name="departmentId" cfsqltype="integer" default="0";
+	property name="departmentId" cfsqltype="integer" valtype="foreignkey" default="0";
 	property name="department" bean="department" joinType="one" fkName="departmentId" default="";
 
-	property name="userTypeId" cfsqltype="integer" default="0";
+	property name="userTypeId" cfsqltype="integer" isrequired="true" valtype="foreignkey" default="0";
 	property name="userType" bean="userType" joinType="one" fkName="userTypeId" default="";
 
 	// many-to-many relationships

--- a/samples/model/beans/user.cfc
+++ b/samples/model/beans/user.cfc
@@ -6,17 +6,17 @@ component accessors="true" extends="cfmlDataMapper.model.base.bean"
 
 	// columns
 	property name="id" columnName="userId" cfsqltype="integer" isidentity="true" default="0";
-	property name="firstName" cfsqltype="varchar" maxlength="50" default="";
-	property name="lastName" cfsqltype="varchar" maxlength="50" default="";
-	property name="email" cfsqltype="varchar" maxlength="50" null="true" default="";
+	property name="firstName" cfsqltype="varchar" maxlength="50" isrequired="true" default="";
+	property name="lastName" cfsqltype="varchar" maxlength="50" isrequired="true" default="";
+	property name="email" cfsqltype="varchar" maxlength="50"default="";
 	property name="createDate" cfsqltype="timestamp" insert="false" default="";
-	property name="updateDate" cfsqltype="timestamp" default="";
+	property name="updateDate" cfsqltype="timestamp" isrequired="true" default="";
 
 	// many-to-one relationships
-	property name="departmentId" cfsqltype="integer" null="true" default="0";
+	property name="departmentId" cfsqltype="integer" default="0";
 	property name="department" bean="department" joinType="one" fkName="departmentId" default="";
 
-	property name="userTypeId" cfsqltype="integer" null="true" default="0";
+	property name="userTypeId" cfsqltype="integer" default="0";
 	property name="userType" bean="userType" joinType="one" fkName="userTypeId" default="";
 
 	// many-to-many relationships

--- a/tests/specs/DataFactory.cfc
+++ b/tests/specs/DataFactory.cfc
@@ -447,6 +447,8 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 						insert = true,
 						isidentity = true,
 						isrequired = false,
+						valtype = "",
+						cfsqltype = "cf_sql_integer",
 						minvalue = 0,
 						maxvalue = 0,
 						minlength = 0,
@@ -552,6 +554,15 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 					expect( function(){ testClass.validatePropertyMetadata( metadata=propertyMetadata, beanname="test" ); } )
 						.toThrow(type="application", regex="(isrequired)");
+				});
+
+
+				it( "errors if the valtype attribute of a property is foreignkey and sqltype isn't integer", function(){
+					propertyMetadata.valtype = "foreignkey";
+					propertyMetadata.sqltype = "cf_sql_varchar";
+
+					expect( function(){ testClass.validatePropertyMetadata( metadata=propertyMetadata, beanname="test" ); } )
+						.toThrow(type="application", regex="(foreignkey)");
 				});
 
 

--- a/tests/specs/DataFactory.cfc
+++ b/tests/specs/DataFactory.cfc
@@ -446,7 +446,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 						name = "user",
 						insert = true,
 						isidentity = true,
-						null = true,
+						isrequired = false,
 						minvalue = 0,
 						maxvalue = 0,
 						minlength = 0,
@@ -547,11 +547,11 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 				});
 
 
-				it( "errors if the null attribute of a property is not a boolean", function(){
-					propertyMetadata.null = "test";
+				it( "errors if the isrequired attribute of a property is not a boolean", function(){
+					propertyMetadata.isrequired = "test";
 
 					expect( function(){ testClass.validatePropertyMetadata( metadata=propertyMetadata, beanname="test" ); } )
-						.toThrow(type="application", regex="(null)");
+						.toThrow(type="application", regex="(isrequired)");
 				});
 
 
@@ -678,7 +678,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 					expect( result ).toHaveKey( "columnName" );
 					expect( result ).toHaveKey( "insert" );
 					expect( result ).toHaveKey( "isidentity" );
-					expect( result ).toHaveKey( "null" );
+					expect( result ).toHaveKey( "isrequired" );
 					expect( result ).toHaveKey( "sqltype" );
 					expect( result ).toHaveKey( "valtype" );
 					expect( result ).toHaveKey( "regex" );

--- a/tests/specs/DataFactory.cfc
+++ b/tests/specs/DataFactory.cfc
@@ -749,6 +749,14 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 				});
 
 
+				it( "returns the numeric datatype for the cf_sql_bigint sqltype", function(){
+					var result = testClass.getDatatype( valtype="", sqltype="cf_sql_bigint" );
+
+					expect( result ).toBeString();
+					expect( result ).toBe( "numeric" );
+				});
+
+
 				it( "returns the numeric datatype for the cf_sql_integer sqltype", function(){
 					var result = testClass.getDatatype( valtype="", sqltype="cf_sql_integer" );
 

--- a/tests/specs/MSSQLService.cfc
+++ b/tests/specs/MSSQLService.cfc
@@ -103,23 +103,23 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 				// getSelectAsField()
 				it( "return the just the column name if the property isn't an integer", function(){
-					var result = testClass.getSelectAsField( propname="name", columnname="[fullname]", sqltype="cf_sql_varchar", isNull=true );
+					var result = testClass.getSelectAsField( propname="name", columnname="[fullname]", sqltype="cf_sql_varchar", isRequired=false );
 
 					expect( result ).toBeString();
 					expect( result ).toBe( "[fullname] AS [name]" );
 				});
 
 
-				it( "return the just the column name if the property is an integer but isn't null", function(){
-					var result = testClass.getSelectAsField( propname="name", columnname="[fullname]", sqltype="cf_sql_integer", isNull=false );
+				it( "return the just the column name if the property is an integer and is required", function(){
+					var result = testClass.getSelectAsField( propname="name", columnname="[fullname]", sqltype="cf_sql_integer", isRequired=true );
 
 					expect( result ).toBeString();
 					expect( result ).toBe( "[fullname] AS [name]" );
 				});
 
 
-				it( "return the column name defaulted to 0 if the property is an integer and it is null", function(){
-					var result = testClass.getSelectAsField( propname="name", columnname="[fullname]", sqltype="cf_sql_integer", isNull=true );
+				it( "return the column name defaulted to 0 if the property is an integer and it is not required", function(){
+					var result = testClass.getSelectAsField( propname="name", columnname="[fullname]", sqltype="cf_sql_integer", isRequired=false );
 
 					expect( result ).toBeString();
 					expect( result ).toBe( "ISNULL([fullname],0) AS [name]" );

--- a/tests/specs/MySQLService.cfc
+++ b/tests/specs/MySQLService.cfc
@@ -97,24 +97,24 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 
 				// getSelectAsField()
-				it( "return the just the column name if the property isn't an integer", function(){
-					var result = testClass.getSelectAsField( propname="name", columnname="`fullname`", sqltype="cf_sql_varchar", isNull=true );
+				it( "return the just the column name if the property is not required", function(){
+					var result = testClass.getSelectAsField( propname="name", columnname="`fullname`", sqltype="cf_sql_varchar", isRequired=false );
 
 					expect( result ).toBeString();
 					expect( result ).toBe( "`fullname` AS `name`" );
 				});
 
 
-				it( "return the just the column name if the property is an integer but isn't null", function(){
-					var result = testClass.getSelectAsField( propname="name", columnname="`fullname`", sqltype="cf_sql_integer", isNull=false );
+				it( "return the just the column name if the property is an integer but is required", function(){
+					var result = testClass.getSelectAsField( propname="name", columnname="`fullname`", sqltype="cf_sql_integer", isRequired=true );
 
 					expect( result ).toBeString();
 					expect( result ).toBe( "`fullname` AS `name`" );
 				});
 
 
-				it( "return the column name defaulted to 0 if the property is an integer and it is null", function(){
-					var result = testClass.getSelectAsField( propname="name", columnname="`fullname`", sqltype="cf_sql_integer", isNull=true );
+				it( "return the column name defaulted to 0 if the property is an integer and it is not required", function(){
+					var result = testClass.getSelectAsField( propname="name", columnname="`fullname`", sqltype="cf_sql_integer", isRequired=false );
 
 					expect( result ).toBeString();
 					expect( result ).toBe( "IFNULL(`fullname`,0) AS `name`" );

--- a/tests/specs/SQLService.cfc
+++ b/tests/specs/SQLService.cfc
@@ -12,6 +12,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 				beanmap = {
 					bean = "user",
 					schema = "",
+					database = "",
 					table = "users",
 					primarykey = "id",
 					orderby = "name",

--- a/tests/specs/SQLService.cfc
+++ b/tests/specs/SQLService.cfc
@@ -338,8 +338,8 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 					expect( result ).toBeStruct();
 					expect( result ).toHaveKey( "value" );
 					expect( result ).toHaveKey( "cfsqltype" );
-					expect( result ).toHaveKey( "null" );
-					expect( result.null ).toBeFalse();
+					expect( result ).toHaveKey( "usenull" );
+					expect( result.usenull ).toBeFalse();
 				});
 
 
@@ -351,8 +351,8 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 					expect( result ).toBeStruct();
 					expect( result ).toHaveKey( "value" );
 					expect( result ).toHaveKey( "cfsqltype" );
-					expect( result ).toHaveKey( "null" );
-					expect( result.null ).toBeTrue();
+					expect( result ).toHaveKey( "usenull" );
+					expect( result.usenull ).toBeTrue();
 				});
 
 
@@ -366,8 +366,8 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 					expect( result ).toBeStruct();
 					expect( result ).toHaveKey( "value" );
 					expect( result ).toHaveKey( "cfsqltype" );
-					expect( result ).toHaveKey( "null" );
-					expect( result.null ).toBeTrue();
+					expect( result ).toHaveKey( "usenull" );
+					expect( result.usenull ).toBeTrue();
 				});
 
 
@@ -379,8 +379,8 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 					expect( result ).toBeStruct();
 					expect( result ).toHaveKey( "value" );
 					expect( result ).toHaveKey( "cfsqltype" );
-					expect( result ).toHaveKey( "null" );
-					expect( result.null ).toBeFalse();
+					expect( result ).toHaveKey( "usenull" );
+					expect( result.usenull ).toBeFalse();
 				});
 
 			});

--- a/tests/specs/SQLService.cfc
+++ b/tests/specs/SQLService.cfc
@@ -23,7 +23,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 							insert = true,
 							datatype = "integer",
 							sqltype = "cf_sql_integer",
-							"null" = true,
+							isrequired = false,
 							isidentity = true
 						},
 						email = {
@@ -33,7 +33,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 							insert = true,
 							datatype = "string",
 							sqltype = "cf_sql_varchar",
-							"null" = true
+							isrequired = false
 						}
 					}
 				};
@@ -648,8 +648,8 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 						});
 
 
-						it( "returns a field string for the select statement if it is null and an integer", function(){
-							beanmap.properties.id.null = true;
+						it( "returns a field string for the select statement if it is not required and an integer", function(){
+							beanmap.properties.id.isrequired = false;
 							args.prop=beanmap.properties.id;
 							args.type = "select";
 

--- a/tests/specs/ValidationService.cfc
+++ b/tests/specs/ValidationService.cfc
@@ -92,7 +92,15 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 				// validateRequired()
 				it( "returns an empty string if the value is required and has a length", function(){
-					var result = testClass.validateRequired( value="This is a sentence.", displayname="Word" );
+					var result = testClass.validateRequired( datatype="string", value="This is a sentence.", displayname="Word" );
+
+					expect( result ).toBeString();
+					expect( result ).toBeEmpty();
+				});
+
+
+				it( "returns an empty string if the numeric value is required and is above 0", function(){
+					var result = testClass.validateRequired( datatype="numeric", value=1, displayname="Number" );
 
 					expect( result ).toBeString();
 					expect( result ).toBeEmpty();
@@ -100,10 +108,19 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 
 				it( "returns an error message if the value is required and does not have a length", function(){
-					var result = testClass.validateRequired( value="", displayname="Word" );
+					var result = testClass.validateRequired( datatype="string", value="", displayname="Word" );
 
 					expect( result ).toBeString();
 					expect( result ).toMatch( "(Word)" );
+					expect( result ).toMatch( "(required)" );
+				});
+
+
+				it( "returns an error message if the numeric value is required and is 0", function(){
+					var result = testClass.validateRequired( datatype="numeric", value=0, displayname="Number" );
+
+					expect( result ).toBeString();
+					expect( result ).toMatch( "(Number)" );
 					expect( result ).toMatch( "(required)" );
 				});
 

--- a/tests/specs/ValidationService.cfc
+++ b/tests/specs/ValidationService.cfc
@@ -493,15 +493,21 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 			});
 
 
+			// validateBean()
 			describe("calls public functions and", function(){
 
 				beforeEach(function( currentSpec ){
 					userBean = createMock("model.beans.user");
 					userBean.$( "getPropertyValue" ).$args( item="test" ).$results( "test" );
+					userBean.$( "getPropertyValue" ).$args( item="name" ).$results( "name" );
 
 					beanmap = {
 						properties = {
 							test = {
+								insert = true,
+								isidentity = false
+							},
+							name = {
 								insert = true,
 								isidentity = false
 							}
@@ -512,13 +518,12 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 				});
 
 
-				// validateBean()
 				it( "returns an empty array if the bean's property value matches the beanmap's property definition", function(){
 					testClass.$( "validateBeanProperty", [] );
 
 					var result = testClass.validateBean( beanmap=beanmap, bean=userBean );
 
-					expect( testClass.$once("validateBeanProperty") ).toBeTrue();
+					expect( testClass.$count("validateBeanProperty") ).toBe(2);
 
 					expect( result ).toBeArray();
 					expect( result ).toBeEmpty();
@@ -527,6 +532,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 				it( "returns an empty array if the bean's property won't be inserted", function(){
 					beanmap.properties.test.insert = false;
+					beanmap.properties.name.insert = false;
 
 					var result = testClass.validateBean( beanmap=beanmap, bean=userBean );
 
@@ -539,6 +545,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 				it( "returns an empty array if the bean's property is an identity", function(){
 					beanmap.properties.test.isidentity = true;
+					beanmap.properties.name.isidentity = true;
 
 					var result = testClass.validateBean( beanmap=beanmap, bean=userBean );
 
@@ -552,10 +559,14 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 				it( "returns an array of error messages if the bean's data doesn't match the beanmap definition", function(){
 					var result = testClass.validateBean( beanmap=beanmap, bean=userBean );
 
-					expect( testClass.$once("validateBeanProperty") ).toBeTrue();
+					expect( testClass.$count("validateBeanProperty") ).toBe(2);
 
 					expect( result ).toBeArray();
-					expect( result ).toHaveLength( 1 );
+					expect( result ).toHaveLength( 2 );
+
+					arrayEach(result, function(message){
+						expect( message ).toBeString();
+					});
 				});
 
 			});

--- a/tests/specs/ValidationService.cfc
+++ b/tests/specs/ValidationService.cfc
@@ -353,7 +353,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 						beanProperty = {
 							displayname = "Test",
-							"null" = true,
+							isrequired = false,
 							datatype = "any",
 							regex = "",
 							regexlabel = "",
@@ -380,7 +380,7 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 
 					it( "returns an array with a message if the value does not exist and is required", function(){
-						beanProperty["null"] = false;
+						beanProperty.isrequired = true;
 
 						var result = testClass.validateBeanProperty( value="", beanProperty=beanProperty );
 

--- a/tests/specs/ValidationService.cfc
+++ b/tests/specs/ValidationService.cfc
@@ -116,8 +116,8 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 				});
 
 
-				it( "returns an error message if the numeric value is required and is 0", function(){
-					var result = testClass.validateRequired( datatype="numeric", value=0, displayname="Number" );
+				it( "returns an error message if the foreignkey value is required and is 0", function(){
+					var result = testClass.validateRequired( datatype="foreignkey", value=0, displayname="Number" );
 
 					expect( result ).toBeString();
 					expect( result ).toMatch( "(Number)" );
@@ -238,6 +238,27 @@ component accessors="true" extends="testbox.system.BaseSpec"{
 
 						expect( result ).toBeString();
 						expect( result ).toMatch( "(Age)" );
+						expect( result ).toMatch( "(numeric)" );
+					});
+
+
+					it( "returns an empty string if the foreignkey is numeric", function(){
+						var result = testClass.validateByDataType( datatype="foreignkey", value=0, displayname="Type" );
+
+						expect( testClass.$never("validateZipCode") ).toBeTrue();
+
+						expect( result ).toBeString();
+						expect( result ).toBeEmpty();
+					});
+
+
+					it( "returns an error message if the foreignkey isn't numeric", function(){
+						var result = testClass.validateByDataType( datatype="foreignkey", value="", displayname="Type" );
+
+						expect( testClass.$never("validateZipCode") ).toBeTrue();
+
+						expect( result ).toBeString();
+						expect( result ).toMatch( "(Type)" );
 						expect( result ).toMatch( "(numeric)" );
 					});
 


### PR DESCRIPTION
- replace 'null' with 'isrequired' attribute for bean properties
- add 'foreignkey' datatype to use with 'isrequired' to validate relationships
- removed use of 'isNull' as a function argument
- fix validation function so it returns all messages about bean properties
- enable ACF 2018 for Travis CI builds